### PR TITLE
Fix/unmount clear change handler delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relax-form",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A simple form library for react-relax",
   "main": "lib/index.js",
   "scripts": {

--- a/src/RelaxForm.js
+++ b/src/RelaxForm.js
@@ -67,6 +67,10 @@ export default (Component, options = {}) => {
       if (this.unsubscribe) {
         this.unsubscribe();
       }
+
+      if (this.formChangeHandlerDelay) {
+        clearTimeout(this.formChangeHandlerDelay);
+      }
     }
 
     option(name, props = this.props) {
@@ -84,7 +88,12 @@ export default (Component, options = {}) => {
 
     handleFormChange = (change) => {
       this.formState = change.get('form');
-      setTimeout(this.handleChange);
+
+      if (this.formChangeHandlerDelay) {
+        clearTimeout(this.formChangeHandlerDelay);
+      }
+
+      this.formChangeHandlerDelay = setTimeout(this.handleChange);
     }
 
     handleSubmit = (e) => {


### PR DESCRIPTION
Fix clear form changed handler timer on unmount

Also clears timer on each form changed event, making it act more like a debounce.

Now definitely fixes https://github.com/musicglue/profile-components/issues/1190
